### PR TITLE
修复如果过期时间(order_expiration_time)设置为大于60时，倒计时显示错误的bug

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -181,6 +181,7 @@
     let second = Math.round(ms / 1000);
     let minute = Math.floor(second / 60);
     let hour = Math.floor(minute / 60);
+    if(minute > 60) minute %= 60
     if (ms <= 0) {
       layer.alert("支付超时，请重新发起支付！", {icon: 5});
       return;


### PR DESCRIPTION
当前版本，过期时间设置为100，倒计时会显示成【01 : 100 : 00】