### PR TITLE
fix: mysql密码中有特殊字符导致拼接的MysqlDns错误

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"github.com/spf13/viper"
+	"net/url"
 	"os"
 	"time"
 )
@@ -41,8 +42,8 @@ func Init() {
 		RuntimePath,
 		viper.GetString("log_save_path"))
 	MysqlDns = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
-		viper.GetString("mysql_user"),
-		viper.GetString("mysql_passwd"),
+		url.QueryEscape(viper.GetString("mysql_user")),
+		url.QueryEscape(viper.GetString("mysql_passwd")),
 		fmt.Sprintf(
 			"%s:%s",
 			viper.GetString("mysql_host"),


### PR DESCRIPTION
比如 密码是passw@rd 的时候就会出错