### PR TITLE
为了保持代码的简洁，删减无关紧要的代码

### DIFF
--- a/src/model/service/order_service.go
+++ b/src/model/service/order_service.go
@@ -96,9 +96,7 @@ func CreateTransaction(req *request.CreateTransactionRequest) (*response.CreateT
 	tx.Commit()
 	// 超时过期消息队列
 	orderExpirationQueue, _ := handle.NewOrderExpirationQueue(order.TradeId)
-	mq.MClient.Enqueue(orderExpirationQueue, asynq.ProcessIn(config.GetOrderExpirationTimeDuration()),
-		asynq.Retention(config.GetOrderExpirationTimeDuration()),
-	)
+	mq.MClient.Enqueue(orderExpirationQueue, asynq.ProcessIn(config.GetOrderExpirationTimeDuration()))
 	ExpirationTime := carbon.Now().AddMinutes(config.GetOrderExpirationTime()).Timestamp()
 	resp := &response.CreateTransactionResponse{
 		TradeId:        order.TradeId,

--- a/src/model/service/task_service.go
+++ b/src/model/service/task_service.go
@@ -5,9 +5,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/assimon/luuu/config"
-	"github.com/spf13/viper"
-
 	"github.com/assimon/luuu/model/data"
 	"github.com/assimon/luuu/model/request"
 	"github.com/assimon/luuu/mq"
@@ -20,6 +17,7 @@ import (
 	"github.com/gookit/goutil/stdutil"
 	"github.com/hibiken/asynq"
 	"github.com/shopspring/decimal"
+	"github.com/spf13/viper"
 )
 
 const UsdtTrc20ApiUri = "https://apilist.tronscanapi.com/api/transfer/trc20"
@@ -140,9 +138,7 @@ func Trc20CallBack(token string, wg *sync.WaitGroup) {
 		// 回调队列
 		orderCallbackQueue, _ := handle.NewOrderCallbackQueue(order)
 		orderNoticeMaxRetry := viper.GetInt("order_notice_max_retry")
-		mq.MClient.Enqueue(orderCallbackQueue, asynq.MaxRetry(orderNoticeMaxRetry),
-			asynq.Retention(config.GetOrderExpirationTimeDuration()),
-		)
+		mq.MClient.Enqueue(orderCallbackQueue, asynq.MaxRetry(orderNoticeMaxRetry))
 		// mq.MClient.Enqueue(orderCallbackQueue, asynq.MaxRetry(5))
 		// 发送机器人消息
 		msgTpl := `

--- a/src/mq/handle/callback_queue.go
+++ b/src/mq/handle/callback_queue.go
@@ -22,9 +22,7 @@ func NewOrderCallbackQueue(order *mdb.Orders) (*asynq.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	return asynq.NewTask(QueueOrderCallback, payload,
-		asynq.Retention(config.GetOrderExpirationTimeDuration()),
-	), nil
+	return asynq.NewTask(QueueOrderCallback, payload), nil
 }
 
 func OrderCallbackHandle(ctx context.Context, t *asynq.Task) error {

--- a/src/mq/handle/order_expiration_queue.go
+++ b/src/mq/handle/order_expiration_queue.go
@@ -3,7 +3,6 @@ package handle
 import (
 	"context"
 
-	"github.com/assimon/luuu/config"
 	"github.com/assimon/luuu/model/data"
 	"github.com/assimon/luuu/model/mdb"
 	"github.com/hibiken/asynq"
@@ -12,9 +11,7 @@ import (
 const QueueOrderExpiration = "order:expiration"
 
 func NewOrderExpirationQueue(tradeId string) (*asynq.Task, error) {
-	return asynq.NewTask(QueueOrderExpiration, []byte(tradeId),
-		asynq.Retention(config.GetOrderExpirationTimeDuration()),
-	), nil
+	return asynq.NewTask(QueueOrderExpiration, []byte(tradeId)), nil
 }
 
 // OrderExpirationHandle 设置订单过期


### PR DESCRIPTION
由于最新的asynq已经添加了删除孤儿key的相关代码，为了保持代码的简洁，删掉上午添加的历史任务过期时间。

