### PR TITLE
修复收款通知支付时间错误

### DIFF
--- a/src/model/service/task_service.go
+++ b/src/model/service/task_service.go
@@ -337,6 +337,18 @@ func TryProcessEthereumERC20Transfer(contract common.Address, toAddr common.Addr
 }
 
 func sendPaymentNotification(order *mdb.Orders) {
+	if order == nil {
+		return
+	}
+	latest := order
+	if order.TradeId != "" {
+		refreshed, err := data.GetOrderInfoByTradeId(order.TradeId)
+		if err != nil {
+			log.Sugar.Warnf("[notify] reload order failed trade_id=%s err=%v", order.TradeId, err)
+		} else if refreshed != nil {
+			latest = refreshed
+		}
+	}
 	msg := fmt.Sprintf(
 		"🎉 <b>收款成功通知</b>\n\n"+
 			"💰 <b>金额信息</b>\n"+
@@ -350,16 +362,16 @@ func sendPaymentNotification(order *mdb.Orders) {
 			"⏰ <b>时间信息</b>\n"+
 			"├ 创建时间：%s\n"+
 			"└ 支付时间：%s",
-		order.Amount,
-		strings.ToUpper(order.Currency),
-		order.ActualAmount,
-		strings.ToUpper(order.Token),
-		order.TradeId,
-		order.OrderId,
-		networkDisplay(order.Network),
-		order.ReceiveAddress,
-		order.CreatedAt.ToDateTimeString(),
-		carbon.Now().ToDateTimeString(),
+		latest.Amount,
+		strings.ToUpper(latest.Currency),
+		latest.ActualAmount,
+		strings.ToUpper(latest.Token),
+		latest.TradeId,
+		latest.OrderId,
+		networkDisplay(latest.Network),
+		latest.ReceiveAddress,
+		latest.CreatedAt.ToDateTimeString(),
+		latest.UpdatedAt.ToDateTimeString(),
 	)
 	telegram.SendToBot(msg)
 }


### PR DESCRIPTION
修复收款成功通知里的支付时间错误。

当前逻辑直接使用运行时当前时间，导致通知里的支付时间可能与订单真实支付时间不一致。

现在改为发送通知前按 trade_id 重查最新订单，并使用订单的 updated_at 作为支付时间。