### PR TITLE
修复 Docker 部署下收银台静态文件路径错误

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -7,13 +7,20 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/assimon/luuu/util/http_client"
+	"github.com/GMWalletApp/epusdt/util/http_client"
 	"github.com/spf13/viper"
 	"github.com/tidwall/gjson"
 )
+
+// parseFloat is the minimal helper used by the settings bridge; kept
+// here so settings_bridge.go stays import-free.
+func parseFloat(s string) (float64, error) {
+	return strconv.ParseFloat(strings.TrimSpace(s), 64)
+}
 
 var (
 	HTTPAccessLog      bool
@@ -27,15 +34,24 @@ var (
 	TgBotToken         string
 	TgProxy            string
 	TgManage           int64
-	UsdtRate           float64
-	RateApiUrl         string
-	TRON_GRID_API_KEY  string
 	BuildVersion       = "0.0.0-dev"
 	BuildCommit        = "none"
 	BuildDate          = "unknown"
 	configRootPath     string
 	explicitConfigPath string
 )
+
+func resolveExecutableDir() (string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(exePath), nil
+}
 
 func SetConfigPath(path string) {
 	explicitConfigPath = strings.TrimSpace(path)
@@ -57,7 +73,11 @@ func Init() {
 	SQLDebug = viper.GetBool("sql_debug")
 	LogLevel = normalizeLogLevel(viper.GetString("log_level"))
 	StaticPath = normalizeStaticURLPath(viper.GetString("static_path"))
-	StaticFilePath = filepath.Join(configRootPath, strings.TrimPrefix(StaticPath, "/"))
+	exeDir, err := resolveExecutableDir()
+	if err != nil {
+		panic(err)
+	}
+	StaticFilePath = filepath.Join(exeDir, "static")
 	RuntimePath = resolvePathFromBase(configRootPath, viper.GetString("runtime_root_path"), filepath.Join(configRootPath, "runtime"))
 	LogSavePath = resolvePathFromBase(RuntimePath, viper.GetString("log_save_path"), filepath.Join(RuntimePath, "logs"))
 	mustMkdir(RuntimePath)
@@ -70,9 +90,6 @@ func Init() {
 	TgBotToken = viper.GetString("tg_bot_token")
 	TgProxy = viper.GetString("tg_proxy")
 	TgManage = viper.GetInt64("tg_manage")
-
-	RateApiUrl = GetRateApiUrl()
-	TRON_GRID_API_KEY = viper.GetString("tron_grid_api_key")
 }
 
 func mustMkdir(path string) {
@@ -122,6 +139,57 @@ func resolveConfigFilePath() (string, error) {
 		return normalizeConfiguredPath(envPath)
 	}
 	return normalizeConfiguredPath(".env")
+}
+
+// NeedsInstall returns true when the first-run install wizard should run.
+// It returns true if the config file does not exist yet, or if the file
+// exists and contains install=true (an explicit reset flag).
+// Existing installs that have no install key are NOT affected.
+func NeedsInstall() bool {
+	envPath, exists := ResolveConfigPath()
+	if !exists {
+		return true
+	}
+	// Read just the install key without triggering full Init().
+	v := viper.New()
+	v.SetConfigFile(envPath)
+	if err := v.ReadInConfig(); err != nil {
+		// Unreadable config → treat as needing install.
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(v.GetString("install")), "true")
+}
+
+// ResolveConfigPath returns the absolute path to the .env file and whether
+// it currently exists on disk. Unlike resolveConfigFilePath it does not
+// return an error when the file is absent — callers (e.g. the install
+// wizard) need the target path even before the file is written.
+func ResolveConfigPath() (path string, exists bool) {
+	candidate := explicitConfigPath
+	if candidate == "" {
+		if e := strings.TrimSpace(os.Getenv("EPUSDT_CONFIG")); e != "" {
+			candidate = e
+		} else {
+			candidate = ".env"
+		}
+	}
+	// Resolve relative paths against cwd.
+	p := strings.TrimSpace(candidate)
+	if !filepath.IsAbs(p) {
+		cwd, err := os.Getwd()
+		if err == nil {
+			p = filepath.Join(cwd, p)
+		}
+	}
+	info, err := os.Stat(p)
+	if err == nil && info.IsDir() {
+		p = filepath.Join(p, ".env")
+		info, err = os.Stat(p)
+	}
+	if err != nil {
+		return p, false
+	}
+	return p, true
 }
 
 func normalizeConfiguredPath(input string) (string, error) {
@@ -178,11 +246,19 @@ func GetAppUri() string {
 	return viper.GetString("app_uri")
 }
 
-func GetApiAuthToken() string {
-	return viper.GetString("api_auth_token")
+func GetRateApiUrl() string {
+	// settings table wins (admin-configurable); .env and env var remain
+	// as fallbacks for smooth migration from the old layout.
+	if db := settingsRateApiUrl(); db != "" {
+		return db
+	}
+	return GetRateApiUrlFromEnv()
 }
 
-func GetRateApiUrl() string {
+// GetRateApiUrlFromEnv returns the rate API URL read only from the
+// .env / environment variables, bypassing the settings table. Used
+// by bootstrap to seed the settings table from the initial .env value.
+func GetRateApiUrlFromEnv() string {
 	rateURL := viper.GetString("api_rate_url")
 	if rateURL == "" {
 		rateURL = os.Getenv("API_RATE_URL")
@@ -190,7 +266,6 @@ func GetRateApiUrl() string {
 	if rateURL == "" {
 		log.Println("api_rate_url is empty")
 	}
-	RateApiUrl = rateURL
 	return rateURL
 }
 
@@ -212,13 +287,14 @@ func GetRateForCoin(coin string, base string) float64 {
 			if usdtRate > 0 {
 				return 1 / usdtRate
 			}
+			return 0
 		}
 	}
+	return getRateForCoinFromAPI(coin, base)
+}
 
-	baseURL := RateApiUrl
-	if baseURL == "" {
-		baseURL = GetRateApiUrl()
-	}
+func getRateForCoinFromAPI(coin string, base string) float64 {
+	baseURL := GetRateApiUrl()
 	if baseURL == "" {
 		log.Printf("rate api url is empty")
 		return 0.0
@@ -250,14 +326,18 @@ func GetRateForCoin(coin string, base string) float64 {
 }
 
 func GetUsdtRate() float64 {
-	forcedUsdtRate := viper.GetFloat64("forced_usdt_rate")
-	if forcedUsdtRate > 0 {
-		return forcedUsdtRate
+	// Only the admin setting can force the USDT/CNY rate. When the
+	// setting is unset, zero, or negative, fall back to the rate API.
+	if forced := settingsForcedUsdtRate(); forced > 0 {
+		return forced
 	}
-	if UsdtRate <= 0 {
-		return 6.4
+
+	apiRate := getRateForCoinFromAPI("usdt", "cny")
+	if apiRate > 0 {
+		return 1 / apiRate
 	}
-	return UsdtRate
+	log.Printf("usdt/cny rate unavailable: rate.forced_usdt_rate <= 0 and rate api returned no data")
+	return 0
 }
 
 func GetOrderExpirationTime() int {
@@ -327,24 +407,4 @@ func GetCallbackRetryBaseDuration() time.Duration {
 		seconds = 5
 	}
 	return time.Duration(seconds) * time.Second
-}
-
-func GetSolanaRpcUrl() string {
-	rpcUrl := viper.GetString("solana_rpc_url")
-	if rpcUrl == "" {
-		return "https://api.mainnet-beta.solana.com"
-	}
-	return rpcUrl
-}
-
-func GetEthereumWsUrl() string {
-	return strings.TrimSpace(viper.GetString("ethereum_ws_url"))
-}
-
-func GetEpayPid() int {
-	return viper.GetInt("epay_pid")
-}
-
-func GetEpayKey() string {
-	return viper.GetString("epay_key")
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,10 +1,51 @@
 package config
 
 import (
+	"io"
+	"math"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/GMWalletApp/epusdt/util/http_client"
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/viper"
 )
+
+func installSettingsGetter(t *testing.T, values map[string]string) {
+	t.Helper()
+
+	oldGetter := SettingsGetString
+	SettingsGetString = func(key string) string {
+		return values[key]
+	}
+	t.Cleanup(func() {
+		SettingsGetString = oldGetter
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func installMockHTTPClient(t *testing.T, handler roundTripFunc) {
+	t.Helper()
+
+	oldFactory := http_client.ClientFactory
+	http_client.ClientFactory = func() *resty.Client {
+		client := resty.NewWithClient(&http.Client{Transport: handler})
+		client.SetTimeout(10 * time.Second)
+		return client
+	}
+	t.Cleanup(func() {
+		http_client.ClientFactory = oldFactory
+	})
+}
 
 func TestNormalizeConfiguredPathUsesExplicitFile(t *testing.T) {
 	t.Helper()
@@ -133,5 +174,167 @@ func TestResolveConfigFilePathPrefersExplicitOverEnv(t *testing.T) {
 	}
 	if got != flagPath {
 		t.Fatalf("config path = %s, want %s", got, flagPath)
+	}
+}
+
+func TestInitUsesExecutableStaticDir(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".env")
+	if err := os.WriteFile(configPath, []byte(strings.Join([]string{
+		"app_name=test",
+		"static_path=/static",
+		"runtime_root_path=./runtime",
+		"log_save_path=./logs",
+	}, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	SetConfigPath(configPath)
+	t.Cleanup(func() {
+		SetConfigPath("")
+	})
+
+	exeDir, err := resolveExecutableDir()
+	if err != nil {
+		t.Fatalf("resolve executable dir: %v", err)
+	}
+
+	Init()
+
+	wantStaticFilePath := filepath.Join(exeDir, "static")
+	if StaticFilePath != wantStaticFilePath {
+		t.Fatalf("StaticFilePath = %s, want %s", StaticFilePath, wantStaticFilePath)
+	}
+
+	wantRuntimePath := filepath.Join(root, "runtime")
+	if RuntimePath != wantRuntimePath {
+		t.Fatalf("RuntimePath = %s, want %s", RuntimePath, wantRuntimePath)
+	}
+}
+
+func TestGetUsdtRatePrefersPositiveAdminOverride(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("API_RATE_URL", "")
+
+	apiCalled := false
+	installMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		apiCalled = true
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     http.StatusText(http.StatusInternalServerError),
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    r,
+		}, nil
+	})
+
+	installSettingsGetter(t, map[string]string{
+		"rate.forced_usdt_rate": "7.25",
+		"rate.api_url":          "https://rate.example.test",
+	})
+
+	got := GetUsdtRate()
+	if got != 7.25 {
+		t.Fatalf("GetUsdtRate() = %v, want 7.25", got)
+	}
+	if apiCalled {
+		t.Fatalf("rate API should not be called when rate.forced_usdt_rate > 0")
+	}
+}
+
+func TestGetUsdtRateUsesAPIWhenAdminOverrideIsNotPositive(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("API_RATE_URL", "")
+
+	installMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/cny.json" {
+			t.Fatalf("rate api path = %s, want /cny.json", r.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"cny":{"usdt":0.14635}}`)),
+			Request:    r,
+		}, nil
+	})
+
+	installSettingsGetter(t, map[string]string{
+		"rate.forced_usdt_rate": "-1",
+		"rate.api_url":          "https://rate.example.test",
+	})
+
+	got := GetUsdtRate()
+	want := 1 / 0.14635
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("GetUsdtRate() = %v, want %v", got, want)
+	}
+
+	rate := GetRateForCoin("usdt", "cny")
+	if math.Abs(rate-0.14635) > 1e-9 {
+		t.Fatalf("GetRateForCoin(usdt, cny) = %v, want 0.14635", rate)
+	}
+}
+
+func TestGetUsdtRateReturnsZeroWhenAPIUnavailableWithoutAdminOverride(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("API_RATE_URL", "")
+
+	installMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Status:     "502 Bad Gateway",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    r,
+		}, nil
+	})
+
+	installSettingsGetter(t, map[string]string{
+		"rate.forced_usdt_rate": "0",
+		"rate.api_url":          "https://rate.example.test",
+	})
+
+	if got := GetUsdtRate(); got != 0 {
+		t.Fatalf("GetUsdtRate() = %v, want 0", got)
+	}
+	if got := GetRateForCoin("usdt", "cny"); got != 0 {
+		t.Fatalf("GetRateForCoin(usdt, cny) = %v, want 0", got)
+	}
+}
+
+func TestGetRateForCoinCallsRateAPIOnceForUsdtCnyFailure(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("API_RATE_URL", "")
+
+	callCount := 0
+	installMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		callCount++
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Status:     "502 Bad Gateway",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    r,
+		}, nil
+	})
+
+	installSettingsGetter(t, map[string]string{
+		"rate.forced_usdt_rate": "0",
+		"rate.api_url":          "https://rate.example.test",
+	})
+
+	if got := GetRateForCoin("usdt", "cny"); got != 0 {
+		t.Fatalf("GetRateForCoin(usdt, cny) = %v, want 0", got)
+	}
+	if callCount != 1 {
+		t.Fatalf("rate api call count = %d, want 1", callCount)
 	}
 }


### PR DESCRIPTION
- 静态目录改为读取可执行文件旁边释放的 `static`
- 补充对应测试
- 可修复 `#55` 中 Docker 部署后收银台缺失/500 的问题