### PR TITLE
为 EVM WebSocket 监听增加断线补扫能力

### DIFF
--- a/src/task/listen_bsc.go
+++ b/src/task/listen_bsc.go
@@ -77,7 +77,7 @@ func runBscListener(contracts []common.Address) {
 		Topics:    [][]common.Hash{},
 	}
 
-	runEvmWsLogListener(ctx, "[BSC-WS]", wsNode, query, func(client *ethclient.Client, vLog types.Log) {
+	runEvmWsLogListener(ctx, "[BSC-WS]", mdb.NetworkBsc, wsNode, query, func(client *ethclient.Client, vLog types.Log) {
 		if len(vLog.Topics) < 3 {
 			return
 		}

--- a/src/task/listen_eth.go
+++ b/src/task/listen_eth.go
@@ -82,7 +82,7 @@ func runEthereumListener(contracts []common.Address) {
 		Topics:    [][]common.Hash{},
 	}
 
-	runEvmWsLogListener(ctx, "[ETH-WS]", wsNode, query, func(client *ethclient.Client, vLog types.Log) {
+	runEvmWsLogListener(ctx, "[ETH-WS]", mdb.NetworkEthereum, wsNode, query, func(client *ethclient.Client, vLog types.Log) {
 		if len(vLog.Topics) < 3 {
 			return
 		}

--- a/src/task/listen_evm_backfill.go
+++ b/src/task/listen_evm_backfill.go
@@ -1,0 +1,129 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/GMWalletApp/epusdt/model/data"
+	"github.com/GMWalletApp/epusdt/model/mdb"
+	"github.com/GMWalletApp/epusdt/util/log"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+var (
+	evmBlockNumber = func(ctx context.Context, client *ethclient.Client) (uint64, error) {
+		return client.BlockNumber(ctx)
+	}
+	evmFilterLogs = func(ctx context.Context, client *ethclient.Client, query ethereum.FilterQuery) ([]types.Log, error) {
+		return client.FilterLogs(ctx, query)
+	}
+	evmBackfillChunkSize         uint64 = 500
+	evmBackfillBootstrapLookback uint64 = 128
+)
+
+func backfillEvmLogs(ctx context.Context, client *ethclient.Client, logPrefix, network string, baseQuery ethereum.FilterQuery, handleLog func(*ethclient.Client, types.Log)) (uint64, error) {
+	latestBlock, err := evmBlockNumber(ctx, client)
+	if err != nil {
+		return 0, fmt.Errorf("get latest block: %w", err)
+	}
+
+	startBlock := evmBackfillStartBlock(network, latestBlock)
+	if latestBlock < startBlock {
+		startBlock = latestBlock
+	}
+	if latestBlock > startBlock {
+		log.Sugar.Infof("%s backfilling blocks %d-%d", logPrefix, startBlock, latestBlock)
+	}
+
+	chunkSize := evmBackfillChunkSize
+	if chunkSize == 0 {
+		chunkSize = 1
+	}
+
+	for from := startBlock; from <= latestBlock; {
+		to := from + chunkSize - 1
+		if to < from || to > latestBlock {
+			to = latestBlock
+		}
+
+		query := baseQuery
+		query.FromBlock = new(big.Int).SetUint64(from)
+		query.ToBlock = new(big.Int).SetUint64(to)
+
+		logs, err := evmFilterLogs(ctx, client, query)
+		if err != nil {
+			return 0, fmt.Errorf("filter logs %d-%d: %w", from, to, err)
+		}
+		sort.Slice(logs, func(i, j int) bool {
+			if logs[i].BlockNumber != logs[j].BlockNumber {
+				return logs[i].BlockNumber < logs[j].BlockNumber
+			}
+			if logs[i].TxIndex != logs[j].TxIndex {
+				return logs[i].TxIndex < logs[j].TxIndex
+			}
+			return logs[i].Index < logs[j].Index
+		})
+		for _, vLog := range logs {
+			if vLog.Removed {
+				continue
+			}
+			handleLog(client, vLog)
+		}
+		if err := saveEvmBackfillCursor(network, to); err != nil {
+			return 0, fmt.Errorf("save cursor %d: %w", to, err)
+		}
+
+		if to == latestBlock {
+			break
+		}
+		from = to + 1
+	}
+
+	return latestBlock, nil
+}
+
+func evmBackfillStartBlock(network string, latestBlock uint64) uint64 {
+	if cursor, ok := loadEvmBackfillCursor(network); ok {
+		if cursor > latestBlock {
+			return latestBlock
+		}
+		return cursor
+	}
+	if evmBackfillBootstrapLookback <= 1 || latestBlock == 0 {
+		return latestBlock
+	}
+	if latestBlock+1 <= evmBackfillBootstrapLookback {
+		return 0
+	}
+	return latestBlock - evmBackfillBootstrapLookback + 1
+}
+
+func loadEvmBackfillCursor(network string) (uint64, bool) {
+	raw := strings.TrimSpace(data.GetSettingString(evmBackfillCursorSettingKey(network), ""))
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func saveEvmBackfillCursor(network string, block uint64) error {
+	if current, ok := loadEvmBackfillCursor(network); ok && current >= block {
+		return nil
+	}
+	return data.SetSetting(mdb.SettingGroupSystem, evmBackfillCursorSettingKey(network), strconv.FormatUint(block, 10), mdb.SettingTypeInt)
+}
+
+func evmBackfillCursorSettingKey(network string) string {
+	return "system.evm_backfill_cursor." + strings.ToLower(strings.TrimSpace(network))
+}

--- a/src/task/listen_evm_backfill_test.go
+++ b/src/task/listen_evm_backfill_test.go
@@ -1,0 +1,165 @@
+package task
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/GMWalletApp/epusdt/internal/testutil"
+	"github.com/GMWalletApp/epusdt/model/data"
+	"github.com/GMWalletApp/epusdt/model/mdb"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+func TestEvmBackfillCursorRoundTrip(t *testing.T) {
+	cleanup := testutil.SetupTestDatabases(t)
+	defer cleanup()
+	if err := data.ReloadSettings(); err != nil {
+		t.Fatalf("ReloadSettings(): %v", err)
+	}
+
+	if err := saveEvmBackfillCursor(mdb.NetworkEthereum, 12345); err != nil {
+		t.Fatalf("saveEvmBackfillCursor(): %v", err)
+	}
+
+	got, ok := loadEvmBackfillCursor(mdb.NetworkEthereum)
+	if !ok {
+		t.Fatal("loadEvmBackfillCursor() ok=false, want true")
+	}
+	if got != 12345 {
+		t.Fatalf("loadEvmBackfillCursor() = %d, want 12345", got)
+	}
+}
+
+func TestBackfillEvmLogsUsesSavedCursorAndPersistsLatest(t *testing.T) {
+	cleanup := testutil.SetupTestDatabases(t)
+	defer cleanup()
+	if err := data.ReloadSettings(); err != nil {
+		t.Fatalf("ReloadSettings(): %v", err)
+	}
+
+	oldBlockNumber := evmBlockNumber
+	oldFilterLogs := evmFilterLogs
+	oldChunkSize := evmBackfillChunkSize
+	t.Cleanup(func() {
+		evmBlockNumber = oldBlockNumber
+		evmFilterLogs = oldFilterLogs
+		evmBackfillChunkSize = oldChunkSize
+	})
+
+	evmBackfillChunkSize = 5
+	evmBlockNumber = func(context.Context, *ethclient.Client) (uint64, error) {
+		return 20, nil
+	}
+
+	var ranges [][2]uint64
+	evmFilterLogs = func(_ context.Context, _ *ethclient.Client, query ethereum.FilterQuery) ([]types.Log, error) {
+		from := query.FromBlock.Uint64()
+		to := query.ToBlock.Uint64()
+		ranges = append(ranges, [2]uint64{from, to})
+		switch {
+		case from == 10 && to == 14:
+			return []types.Log{
+				{BlockNumber: 12, TxIndex: 1, Index: 0},
+				{BlockNumber: 10, TxIndex: 2, Index: 0},
+			}, nil
+		case from == 15 && to == 19:
+			return []types.Log{
+				{BlockNumber: 17, TxIndex: 0, Index: 1},
+			}, nil
+		case from == 20 && to == 20:
+			return []types.Log{
+				{BlockNumber: 20, TxIndex: 0, Index: 0},
+			}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	if err := saveEvmBackfillCursor(mdb.NetworkEthereum, 10); err != nil {
+		t.Fatalf("seed cursor: %v", err)
+	}
+
+	var handled []uint64
+	head, err := backfillEvmLogs(context.Background(), nil, "[TEST]", mdb.NetworkEthereum, ethereum.FilterQuery{}, func(_ *ethclient.Client, vLog types.Log) {
+		handled = append(handled, vLog.BlockNumber)
+	})
+	if err != nil {
+		t.Fatalf("backfillEvmLogs(): %v", err)
+	}
+	if head != 20 {
+		t.Fatalf("backfillEvmLogs() head = %d, want 20", head)
+	}
+
+	wantRanges := [][2]uint64{{10, 14}, {15, 19}, {20, 20}}
+	if !reflect.DeepEqual(ranges, wantRanges) {
+		t.Fatalf("backfill ranges = %#v, want %#v", ranges, wantRanges)
+	}
+
+	wantHandled := []uint64{10, 12, 17, 20}
+	if !reflect.DeepEqual(handled, wantHandled) {
+		t.Fatalf("handled blocks = %#v, want %#v", handled, wantHandled)
+	}
+
+	cursor, ok := loadEvmBackfillCursor(mdb.NetworkEthereum)
+	if !ok {
+		t.Fatal("loadEvmBackfillCursor() ok=false, want true")
+	}
+	if cursor != 20 {
+		t.Fatalf("cursor = %d, want 20", cursor)
+	}
+}
+
+func TestBackfillEvmLogsUsesBootstrapLookbackWithoutCursor(t *testing.T) {
+	cleanup := testutil.SetupTestDatabases(t)
+	defer cleanup()
+	if err := data.ReloadSettings(); err != nil {
+		t.Fatalf("ReloadSettings(): %v", err)
+	}
+
+	oldBlockNumber := evmBlockNumber
+	oldFilterLogs := evmFilterLogs
+	oldChunkSize := evmBackfillChunkSize
+	oldLookback := evmBackfillBootstrapLookback
+	t.Cleanup(func() {
+		evmBlockNumber = oldBlockNumber
+		evmFilterLogs = oldFilterLogs
+		evmBackfillChunkSize = oldChunkSize
+		evmBackfillBootstrapLookback = oldLookback
+	})
+
+	evmBackfillChunkSize = 100
+	evmBackfillBootstrapLookback = 4
+	evmBlockNumber = func(context.Context, *ethclient.Client) (uint64, error) {
+		return 12, nil
+	}
+
+	var ranges [][2]uint64
+	evmFilterLogs = func(_ context.Context, _ *ethclient.Client, query ethereum.FilterQuery) ([]types.Log, error) {
+		ranges = append(ranges, [2]uint64{query.FromBlock.Uint64(), query.ToBlock.Uint64()})
+		return nil, nil
+	}
+
+	head, err := backfillEvmLogs(context.Background(), nil, "[TEST]", mdb.NetworkPolygon, ethereum.FilterQuery{}, func(_ *ethclient.Client, _ types.Log) {})
+	if err != nil {
+		t.Fatalf("backfillEvmLogs(): %v", err)
+	}
+	if head != 12 {
+		t.Fatalf("backfillEvmLogs() head = %d, want 12", head)
+	}
+
+	wantRanges := [][2]uint64{{9, 12}}
+	if !reflect.DeepEqual(ranges, wantRanges) {
+		t.Fatalf("bootstrap ranges = %#v, want %#v", ranges, wantRanges)
+	}
+
+	cursor, ok := loadEvmBackfillCursor(mdb.NetworkPolygon)
+	if !ok {
+		t.Fatal("loadEvmBackfillCursor() ok=false, want true")
+	}
+	if cursor != 12 {
+		t.Fatalf("cursor = %d, want 12", cursor)
+	}
+}

--- a/src/task/listen_evm_ws.go
+++ b/src/task/listen_evm_ws.go
@@ -14,17 +14,27 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+var (
+	evmDialClient = func(rawURL string) (*ethclient.Client, error) {
+		return ethclient.Dial(rawURL)
+	}
+	evmSubscribeLogs = func(ctx context.Context, client *ethclient.Client, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+		return client.SubscribeFilterLogs(ctx, query, ch)
+	}
+)
+
 // runEvmWsLogListener connects to node.Url, subscribes to Transfer logs,
 // and dispatches each log to handleLog. It retries on transient errors
 // with exponential backoff until the node reaches the failure threshold.
 // The ctx lets the caller trigger a clean exit — e.g. when admin disables
 // the chain, the caller cancels the context and the function returns.
-func runEvmWsLogListener(ctx context.Context, logPrefix string, node mdb.RpcNode, query ethereum.FilterQuery, handleLog func(*ethclient.Client, types.Log)) {
+func runEvmWsLogListener(ctx context.Context, logPrefix, network string, node mdb.RpcNode, query ethereum.FilterQuery, handleLog func(*ethclient.Client, types.Log)) {
 	const (
 		minBackoff       = 2 * time.Second
 		maxBackoff       = 60 * time.Second
 		rejoinWait       = 3 * time.Second
 		stableResetAfter = 60 * time.Second
+		logBufferSize    = 256
 	)
 	failWait := minBackoff
 	wsURL := node.Url
@@ -35,7 +45,7 @@ func runEvmWsLogListener(ctx context.Context, logPrefix string, node mdb.RpcNode
 			return
 		}
 
-		client, err := ethclient.Dial(wsURL)
+		client, err := evmDialClient(wsURL)
 		if err != nil {
 			log.Sugar.Warnf("%s dial: %v, retry in %s", logPrefix, err, failWait)
 			if recordEvmWsNodeFailure(logPrefix, node, "dial") {
@@ -48,8 +58,8 @@ func runEvmWsLogListener(ctx context.Context, logPrefix string, node mdb.RpcNode
 			continue
 		}
 
-		logsCh := make(chan types.Log)
-		sub, err := client.SubscribeFilterLogs(ctx, query, logsCh)
+		logsCh := make(chan types.Log, logBufferSize)
+		sub, err := evmSubscribeLogs(ctx, client, query, logsCh)
 		if err != nil {
 			client.Close()
 			log.Sugar.Warnf("%s subscribe: %v, retry in %s", logPrefix, err, failWait)
@@ -62,12 +72,41 @@ func runEvmWsLogListener(ctx context.Context, logPrefix string, node mdb.RpcNode
 			failWait = nextBackoff(failWait, maxBackoff)
 			continue
 		}
+
+		snapshotBlock, err := backfillEvmLogs(ctx, client, logPrefix, network, query, handleLog)
+		if err != nil {
+			sub.Unsubscribe()
+			client.Close()
+			log.Sugar.Warnf("%s backfill: %v, retry in %s", logPrefix, err, failWait)
+			if recordEvmWsNodeFailure(logPrefix, node, "backfill") {
+				return
+			}
+			if !sleepOrDone(ctx, failWait) {
+				return
+			}
+			failWait = nextBackoff(failWait, maxBackoff)
+			continue
+		}
 		failWait = minBackoff
 
-		log.Sugar.Infof("%s connected, subscribed to Transfer logs using WSS node %s", logPrefix, nodeLabel)
+		log.Sugar.Infof("%s connected, subscribed to Transfer logs using WSS node %s (backfilled to block %d)", logPrefix, nodeLabel, snapshotBlock)
 
 		connectedAt := time.Now()
-		recvErr := recvLoop(ctx, client, sub, logsCh, logPrefix, handleLog)
+		lastCursor := snapshotBlock
+		recvErr := recvLoop(ctx, client, sub, logsCh, logPrefix, func(client *ethclient.Client, vLog types.Log) {
+			if vLog.Removed {
+				return
+			}
+			handleLog(client, vLog)
+			if vLog.BlockNumber <= lastCursor {
+				return
+			}
+			if err := saveEvmBackfillCursor(network, vLog.BlockNumber); err != nil {
+				log.Sugar.Warnf("%s save backfill cursor block=%d: %v", logPrefix, vLog.BlockNumber, err)
+				return
+			}
+			lastCursor = vLog.BlockNumber
+		})
 
 		if ctx.Err() != nil {
 			return

--- a/src/task/listen_plasma.go
+++ b/src/task/listen_plasma.go
@@ -76,7 +76,7 @@ func runPlasmaListener(contracts []common.Address) {
 		Topics:    [][]common.Hash{},
 	}
 
-	runEvmWsLogListener(ctx, "[PLASMA-WS]", wsNode, query, func(client *ethclient.Client, vLog types.Log) {
+	runEvmWsLogListener(ctx, "[PLASMA-WS]", mdb.NetworkPlasma, wsNode, query, func(client *ethclient.Client, vLog types.Log) {
 		if len(vLog.Topics) < 3 {
 			return
 		}

--- a/src/task/listen_polygon.go
+++ b/src/task/listen_polygon.go
@@ -76,7 +76,7 @@ func runPolygonListener(contracts []common.Address) {
 		Topics:    [][]common.Hash{},
 	}
 
-	runEvmWsLogListener(ctx, "[POLYGON-WS]", wsNode, query, func(client *ethclient.Client, vLog types.Log) {
+	runEvmWsLogListener(ctx, "[POLYGON-WS]", mdb.NetworkPolygon, wsNode, query, func(client *ethclient.Client, vLog types.Log) {
 		if len(vLog.Topics) < 3 {
 			return
 		}


### PR DESCRIPTION
Closes #83

### 变更内容
- 为 EVM 链增加按网络持久化的补扫游标
- WebSocket 重连后，先用 `FilterLogs` 按区间补扫缺失区块，再恢复实时订阅
- 将公共补扫流程接入 Ethereum、Binance、Polygon、Plasma 监听器
- 补充补扫游标和区间回放测试

### 测试
- `go test -vet=off ./task`
- `go test -vet=off ./model/service`