### PR TITLE
feat(tron): add tron rpc node availability check on startup

### DIFF
--- a/src/task/listen_trc20_block.go
+++ b/src/task/listen_trc20_block.go
@@ -473,14 +473,17 @@ func (s *Scanner) recordRpcFailure(reason string) {
 
 func StartTronBlockScannerListener() {
 	for {
-		scanner := NewScanner()
-		if err := scanner.Init(); err != nil {
-			log.Sugar.Errorf("[TRON-BLOCK] init: %v, retrying...", err)
-			time.Sleep(10 * time.Second)
-			continue
+		if data.IsChainEnabled(mdb.NetworkTron) {
+			scanner := NewScanner()
+			if err := scanner.Init(); err != nil {
+				log.Sugar.Warnf("[TRON-BLOCK] init: %v, retrying...", err)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			scanner.Run()
+			log.Sugar.Warn("[TRON-BLOCK] scanner stopped, restarting...")
+			time.Sleep(3 * time.Second)
 		}
-		scanner.Run()
-		log.Sugar.Warn("[TRON-BLOCK] scanner stopped, restarting...")
-		time.Sleep(3 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 }


### PR DESCRIPTION
The TRON scanner always initializes and attempts to connect to the RPC node upon startup, but this can result in repeated errors in the logs and unnecessary retries when no nodes are enabled.  

By referencing other scanners and adding startup checks to ensure that the scanning program is initialized only when there is an enabled TRON RPC node, stability has been improved and logs have become clearer.