### PR TITLE
feat: add English language support for Telegram bot messages

### DIFF
--- a/src/lang/lang.go
+++ b/src/lang/lang.go
@@ -1,0 +1,89 @@
+package lang
+
+import (
+	"fmt"
+
+	"github.com/GMWalletApp/epusdt/model/data"
+)
+
+const (
+	SettingKeyLanguage = "lang.language"
+	Zh                 = "zh"
+	En                 = "en"
+)
+
+var zh = map[string]string{
+	"select_network":          "请选择要添加的钱包网络",
+	"add_wallet":              "请发送 %s 网络收款地址",
+	"select_network_first":    "请先选择网络，再发送地址。",
+	"wallet_add_fail":         "钱包 [%s] 添加失败：不是合法的 %s 地址",
+	"wallet_add_success":      "钱包 [%s] 添加成功（%s）",
+	"status_enabled":          "已启用✅",
+	"status_disabled":         "已禁用🚫",
+	"btn_add_wallet":          "添加钱包地址",
+	"read_chains_fail":        "读取支持链失败：",
+	"no_available_chains":     "当前没有可用链，请先在后台配置 supported-assets。",
+	"btn_refresh":             "刷新列表",
+	"select_wallet_prompt":    "请选择钱包继续操作",
+	"select_valid_network":    "请选择有效网络",
+	"btn_enable":              "启用",
+	"btn_disable":             "禁用",
+	"btn_delete":              "删除",
+	"btn_back":                "返回",
+	"wallet_detail":           "网络：%s\n地址：%s",
+	"invalid_request":         "请求不合法！",
+	"cmd_start_desc":          "开始",
+	"notify_template": "🎉 <b>收款成功通知</b>\n\n💰 <b>金额信息</b>\n├ 订单金额：<code>%s %s</code>\n└ 实际到账：<code>%s %s</code>\n\n📋 <b>订单信息</b>\n├ 交易号：<code>%s</code>\n├ 订单号：<code>%s</code>\n├ 网络：<code>%s</code>\n└ 钱包地址：<code>%s</code>\n\n⏰ <b>时间信息</b>\n├ 创建时间：%s\n└ 支付时间：%s",
+}
+
+var en = map[string]string{
+	"select_network":          "Please select the wallet network to add",
+	"add_wallet":              "Please send the %s network receiving address",
+	"select_network_first":    "Please select a network first, then send the address.",
+	"wallet_add_fail":         "Wallet [%s] add failed: not a valid %s address",
+	"wallet_add_success":      "Wallet [%s] added successfully (%s)",
+	"status_enabled":          "Enabled✅",
+	"status_disabled":         "Disabled🚫",
+	"btn_add_wallet":          "Add Wallet",
+	"read_chains_fail":        "Failed to read supported chains: ",
+	"no_available_chains":     "No available chains. Configure supported-assets in the admin panel first.",
+	"btn_refresh":             "Refresh",
+	"select_wallet_prompt":    "Select a wallet to continue",
+	"select_valid_network":    "Please select a valid network",
+	"btn_enable":              "Enable",
+	"btn_disable":             "Disable",
+	"btn_delete":              "Delete",
+	"btn_back":                "Back",
+	"wallet_detail":           "Network: %s\nAddress: %s",
+	"invalid_request":         "Invalid request!",
+	"cmd_start_desc":          "Start",
+	"notify_template": "🎉 <b>Payment Received</b>\n\n💰 <b>Amount</b>\n├ Order Amount: <code>%s %s</code>\n└ Actual Received: <code>%s %s</code>\n\n📋 <b>Order</b>\n├ Trade ID: <code>%s</code>\n├ Order ID: <code>%s</code>\n├ Network: <code>%s</code>\n└ Wallet Address: <code>%s</code>\n\n⏰ <b>Time</b>\n├ Created: %s\n└ Paid: %s",
+}
+
+var maps = map[string]map[string]string{
+	Zh: zh,
+	En: en,
+}
+
+func current() string {
+	return data.GetSettingString(SettingKeyLanguage, Zh)
+}
+
+func T(key string) string {
+	lang := current()
+	m, ok := maps[lang]
+	if !ok {
+		m = zh
+	}
+	if v, ok := m[key]; ok {
+		return v
+	}
+	if v, ok := zh[key]; ok {
+		return v
+	}
+	return key
+}
+
+func TF(key string, args ...interface{}) string {
+	return fmt.Sprintf(T(key), args...)
+}

--- a/src/model/dao/mdb_table_init.go
+++ b/src/model/dao/mdb_table_init.go
@@ -173,6 +173,7 @@ func seedDefaultSettings() {
 	}
 	defaultRateMode := defaultRateModeForSeed()
 	defaults := []mdb.Setting{
+		{Group: mdb.SettingGroupLang, Key: mdb.SettingKeyLanguage, Value: "zh", Type: mdb.SettingTypeString},
 		{Group: mdb.SettingGroupSystem, Key: mdb.SettingKeyAmountPrecision, Value: "2", Type: mdb.SettingTypeInt},
 		{Group: mdb.SettingGroupSystem, Key: mdb.SettingKeySystemLogLevel, Value: mdb.SettingDefaultSystemLogLevel, Type: mdb.SettingTypeString},
 		{Group: mdb.SettingGroupRate, Key: mdb.SettingKeyRateForcedRateList, Value: mdb.SettingDefaultRateForcedRateList, Type: mdb.SettingTypeJSON},

--- a/src/model/mdb/settings.go
+++ b/src/model/mdb/settings.go
@@ -9,6 +9,7 @@ package mdb
 // empty and fall back to hardcoded defaults until an admin sets them. The
 // system.jwt_secret key is auto-generated on first startup.
 const (
+	SettingGroupLang   = "lang"
 	SettingGroupBrand  = "brand"
 	SettingGroupRate   = "rate"
 	SettingGroupSystem = "system"
@@ -46,6 +47,7 @@ const (
 	SettingKeyRateAdjustPercent        = "rate.adjust_percent"
 	SettingKeyRateOkxC2cEnabled        = "rate.okx_c2c_enabled"
 	SettingKeyRateApiUrl               = "rate.api_url"
+	SettingKeyLanguage                 = "lang.language"
 	SettingKeyRateMode                 = "rate.mode"
 	SettingKeyRateCacheTTLSeconds      = "rate.cache_ttl_seconds"
 
@@ -73,7 +75,7 @@ const (
 )
 
 type Setting struct {
-	Group       string `gorm:"column:group;size:32;index:settings_group_index" json:"group" enums:"brand,rate,system,epay,okpay" example:"rate"`
+	Group       string `gorm:"column:group;size:32;index:settings_group_index" json:"group" enums:"lang,brand,rate,system,epay,okpay" example:"rate"`
 	Key         string `gorm:"column:key;uniqueIndex:settings_key_uindex;size:128" json:"key" example:"rate.forced_rate_list"`
 	Value       string `gorm:"column:value;type:text" json:"value" example:"{\"cny\":{\"usdt\":0.14635}}"`
 	Type        string `gorm:"column:type;size:16;default:string" json:"type" enums:"string,int,bool,json" example:"json"`

--- a/src/model/service/task_service.go
+++ b/src/model/service/task_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/GMWalletApp/epusdt/config"
+	"github.com/GMWalletApp/epusdt/lang"
 	"github.com/GMWalletApp/epusdt/model/data"
 	"github.com/GMWalletApp/epusdt/model/mdb"
 	"github.com/GMWalletApp/epusdt/model/request"
@@ -351,22 +352,9 @@ func sendPaymentNotification(order *mdb.Orders) {
 	precision := data.GetAmountPrecision()
 	amountFormat := fmt.Sprintf("%%.%df", precision)
 	msg := fmt.Sprintf(
-		"🎉 <b>收款成功通知</b>\n\n"+
-			"💰 <b>金额信息</b>\n"+
-			"├ 订单金额：<code>"+amountFormat+" %s</code>\n"+
-			"└ 实际到账：<code>"+amountFormat+" %s</code>\n\n"+
-			"📋 <b>订单信息</b>\n"+
-			"├ 交易号：<code>%s</code>\n"+
-			"├ 订单号：<code>%s</code>\n"+
-			"├ 网络：<code>%s</code>\n"+
-			"└ 钱包地址：<code>%s</code>\n\n"+
-			"⏰ <b>时间信息</b>\n"+
-			"├ 创建时间：%s\n"+
-			"└ 支付时间：%s",
-		order.Amount,
-		strings.ToUpper(order.Currency),
-		order.ActualAmount,
-		strings.ToUpper(order.Token),
+		lang.T("notify_template"),
+		amountFormat, order.Amount, strings.ToUpper(order.Currency),
+		amountFormat, order.ActualAmount, strings.ToUpper(order.Token),
 		order.TradeId,
 		order.OrderId,
 		networkDisplay(order.Network),

--- a/src/telegram/command.go
+++ b/src/telegram/command.go
@@ -1,6 +1,9 @@
 package telegram
 
-import tb "gopkg.in/telebot.v3"
+import (
+	"github.com/GMWalletApp/epusdt/lang"
+	tb "gopkg.in/telebot.v3"
+)
 
 const (
 	START_CMD = "/start"
@@ -9,6 +12,6 @@ const (
 var Cmds = []tb.Command{
 	{
 		Text:        START_CMD,
-		Description: "开始",
+		Description: lang.T("cmd_start_desc"),
 	},
 }

--- a/src/telegram/handle.go
+++ b/src/telegram/handle.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GMWalletApp/epusdt/lang"
 	"github.com/GMWalletApp/epusdt/model/data"
 	"github.com/GMWalletApp/epusdt/model/mdb"
 	"github.com/gookit/goutil/mathutil"
@@ -15,8 +16,6 @@ import (
 )
 
 const (
-	ReplaySelectNetwork     = "请选择要添加的钱包网络"
-	ReplayAddWallet         = "请发送 %s 网络收款地址"
 	pendingWalletAddressTTL = 5 * time.Minute
 )
 
@@ -52,13 +51,13 @@ func OnTextMessageHandle(c tb.Context) error {
 	msgText := strings.TrimSpace(msg.Text)
 	state, _ := getPendingWalletAddressState(senderID)
 	if state.Network == "" {
-		_ = c.Send("请先选择网络，再发送地址。")
+		_ = c.Send(lang.T("select_network_first"))
 		return nil
 	}
 
 	var err error
 	if !isValidAddressByNetwork(state.Network, msgText) {
-		_ = c.Send(fmt.Sprintf("钱包 [%s] 添加失败：不是合法的 %s 地址", msgText, strings.ToUpper(state.Network)))
+		_ = c.Send(lang.TF("wallet_add_fail", msgText, strings.ToUpper(state.Network)))
 		return nil
 	}
 	storeAddress := normalizeWalletAddressByNetwork(state.Network, msgText)
@@ -68,7 +67,7 @@ func OnTextMessageHandle(c tb.Context) error {
 	}
 	pendingWalletAddressUsers.Delete(senderID)
 
-	_ = c.Send(fmt.Sprintf("钱包 [%s] 添加成功（%s）", storeAddress, strings.ToUpper(state.Network)))
+	_ = c.Send(lang.TF("wallet_add_success", storeAddress, strings.ToUpper(state.Network)))
 	return WalletList(c)
 }
 
@@ -80,9 +79,9 @@ func WalletList(c tb.Context) error {
 
 	var btnList [][]tb.InlineButton
 	for _, wallet := range wallets {
-		status := "已启用✅"
+		status := lang.T("status_enabled")
 		if wallet.Status == mdb.TokenStatusDisable {
-			status = "已禁用🚫"
+			status = lang.T("status_disabled")
 		}
 		net := wallet.Network
 		if net == "" {
@@ -98,14 +97,14 @@ func WalletList(c tb.Context) error {
 		btnList = append(btnList, []tb.InlineButton{btnInfo})
 	}
 
-	addBtn := tb.InlineButton{Text: "添加钱包地址", Unique: "AddWallet"}
+	addBtn := tb.InlineButton{Text: lang.T("btn_add_wallet"), Unique: "AddWallet"}
 	bots.Handle(&addBtn, func(c tb.Context) error {
 		chains, err := getEnabledSupportedNetworks()
 		if err != nil {
-			return c.Send("读取支持链失败：" + err.Error())
+			return c.Send(lang.T("read_chains_fail") + err.Error())
 		}
 		if len(chains) == 0 {
-			return c.Send("当前没有可用链，请先在后台配置 supported-assets。")
+			return c.Send(lang.T("no_available_chains"))
 		}
 
 		rows := make([][]tb.InlineButton, 0, len(chains))
@@ -118,15 +117,15 @@ func WalletList(c tb.Context) error {
 			bots.Handle(&btn, SelectWalletNetwork)
 			rows = append(rows, []tb.InlineButton{btn})
 		}
-		return c.EditOrSend(ReplaySelectNetwork, &tb.ReplyMarkup{
+		return c.EditOrSend(lang.T("select_network"), &tb.ReplyMarkup{
 			InlineKeyboard: rows,
 		})
 	})
-	refreshBtn := tb.InlineButton{Text: "刷新列表", Unique: "WalletRefresh"}
+	refreshBtn := tb.InlineButton{Text: lang.T("btn_refresh"), Unique: "WalletRefresh"}
 	bots.Handle(&refreshBtn, WalletList)
 	btnList = append(btnList, []tb.InlineButton{addBtn, refreshBtn})
 
-	return c.EditOrSend("请选择钱包继续操作", &tb.ReplyMarkup{
+	return c.EditOrSend(lang.T("select_wallet_prompt"), &tb.ReplyMarkup{
 		InlineKeyboard: btnList,
 	})
 }
@@ -134,7 +133,7 @@ func WalletList(c tb.Context) error {
 func SelectWalletNetwork(c tb.Context) error {
 	network := strings.ToLower(strings.TrimSpace(c.Data()))
 	if network == "" {
-		return c.Send("请选择有效网络")
+		return c.Send(lang.T("select_valid_network"))
 	}
 	if sender := c.Sender(); sender != nil {
 		pendingWalletAddressUsers.Store(sender.ID, pendingWalletAddressState{
@@ -142,7 +141,7 @@ func SelectWalletNetwork(c tb.Context) error {
 			Network:     network,
 		})
 	}
-	return c.Send(fmt.Sprintf(ReplayAddWallet, strings.ToUpper(network)), &tb.ReplyMarkup{
+	return c.Send(lang.TF("add_wallet", strings.ToUpper(network)), &tb.ReplyMarkup{
 		ForceReply: true,
 	})
 }
@@ -155,22 +154,22 @@ func WalletInfo(c tb.Context) error {
 	}
 
 	enableBtn := tb.InlineButton{
-		Text:   "启用",
+		Text:   lang.T("btn_enable"),
 		Unique: "enableBtn",
 		Data:   c.Data(),
 	}
 	disableBtn := tb.InlineButton{
-		Text:   "禁用",
+		Text:   lang.T("btn_disable"),
 		Unique: "disableBtn",
 		Data:   c.Data(),
 	}
 	delBtn := tb.InlineButton{
-		Text:   "删除",
+		Text:   lang.T("btn_delete"),
 		Unique: "delBtn",
 		Data:   c.Data(),
 	}
 	backBtn := tb.InlineButton{
-		Text:   "返回",
+		Text:   lang.T("btn_back"),
 		Unique: "WalletList",
 	}
 
@@ -183,7 +182,7 @@ func WalletInfo(c tb.Context) error {
 	if net == "" {
 		net = mdb.NetworkTron
 	}
-	detail := fmt.Sprintf("网络：%s\n地址：%s", net, tokenInfo.Address)
+	detail := lang.TF("wallet_detail", net, tokenInfo.Address)
 	return c.EditOrReply(detail, &tb.ReplyMarkup{InlineKeyboard: [][]tb.InlineButton{
 		{
 			enableBtn,
@@ -199,7 +198,7 @@ func WalletInfo(c tb.Context) error {
 func EnableWallet(c tb.Context) error {
 	id := mathutil.MustUint(c.Data())
 	if id <= 0 {
-		return c.Send("请求不合法！")
+		return c.Send(lang.T("invalid_request"))
 	}
 	err := data.ChangeWalletAddressStatus(id, mdb.TokenStatusEnable)
 	if err != nil {
@@ -211,7 +210,7 @@ func EnableWallet(c tb.Context) error {
 func DisableWallet(c tb.Context) error {
 	id := mathutil.MustUint(c.Data())
 	if id <= 0 {
-		return c.Send("请求不合法！")
+		return c.Send(lang.T("invalid_request"))
 	}
 	err := data.ChangeWalletAddressStatus(id, mdb.TokenStatusDisable)
 	if err != nil {
@@ -223,7 +222,7 @@ func DisableWallet(c tb.Context) error {
 func DelWallet(c tb.Context) error {
 	id := mathutil.MustUint(c.Data())
 	if id <= 0 {
-		return c.Send("请求不合法！")
+		return c.Send(lang.T("invalid_request"))
 	}
 	err := data.DeleteWalletAddressById(id)
 	if err != nil {


### PR DESCRIPTION
## Summary

Add i18n support for the Telegram bot. Creates a new  package with Chinese (default) and English translations, and a  DB setting to switch between them.

## Changes

- **New**:  — translation map with  and  functions, driven by the  setting
- **New**:  setting key (values: `zh` / `en`), seeded as `zh` by default
- **Updated**: All Chinese strings in , , and  replaced with translation lookups
- **Updated**: The payment success notification template fully translated to English when 

To switch to English, set `lang.language = en` in the admin settings panel or directly in the `settings` table.